### PR TITLE
issue with file uploads when its running concurrently

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -250,3 +250,7 @@ MultiPartUpload.prototype._completeUploads = function(callback) {
 }
 
 module.exports = MultiPartUpload;
+
+function random_seed(){
+    return 'xxxx'.replace(/[xy]/g, function(c) {var r = Math.random()*16|0,v=c=='x'?r:r&0x3|0x8;return v.toString(16);});
+}


### PR DESCRIPTION
i was testing out concurrent file upload of 3-10 files, and mpu file upload temporary file generation causes an issue during concurrency.

apparently date.now() generates the same number for some temporary files, causing the file to be deleted.
