### PR TITLE
fix path.join error on node 0.10 when using noDisk option

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -132,7 +132,7 @@ MultiPartUpload.prototype._handleStream = function(stream, callback) {
     // Create a new part
     function newPart() {
         var partId = parts.length + 1,
-            partFileName = path.resolve(path.join(mpu.tmpDir, 'mpu-' + this.objectName + '-' + random_seed() + '-' + (mpu.uploadId || Date.now()) + '-' + partId)),
+            partFileName = path.resolve(path.join(mpu.tmpDir || '', 'mpu-' + this.objectName + '-' + random_seed() + '-' + (mpu.uploadId || Date.now()) + '-' + partId)),
             partFile = !mpu.noDisk && fs.createWriteStream(partFileName),
             part = {
                 id: partId,


### PR DESCRIPTION
Resolves this error:

```
TypeError: Arguments to path.join must be strings
```
