### PR TITLE
fix noDisk option with binary uploads

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -139,7 +139,7 @@ MultiPartUpload.prototype._handleStream = function(stream, callback) {
                 stream: partFile,
                 fileName: partFileName,
                 length: 0,
-                data: ''
+                data: Buffer('')
             };
 
         parts.push(part);
@@ -188,7 +188,7 @@ MultiPartUpload.prototype._handleStream = function(stream, callback) {
         if (current.stream) {
             current.stream.write(buffer);
         } else {
-            current.data += buffer;
+            current.data = Buffer.concat([current.data, buffer]);
         }
         current.length += buffer.length;
 


### PR DESCRIPTION
Concatenating binary-encoded buffers as strings doesn't work (upload result becomes corrupted). Use Buffer.concat() instead.
