### PR TITLE
Erroring out of _completeUploads if we get an empty response from S3.

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -367,6 +367,7 @@ MultiPartUpload.prototype._completeUploads = function(callback) {
         // Register the response handler
         parse.xmlResponse(req, function(err, body) {
             if (err) return callback(err);
+            if (body === null) return callback('got empty response');
             delete body.$;
             body.size = size;
             mpu.emit('completed', body);


### PR DESCRIPTION
We've been getting some empty responses from S3, even though they're supposed to be sending XML. This change will send the error in a callback instead of producing the "Cannot convert null to object" exception when it tries to delete body.$.
