### PR TITLE
hash the file name incase it includes a path

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -5,6 +5,8 @@ var _ = require('lodash'),
     path = require('path'),
     os = require('os'),
     util = require('util'),
+    crypto = require('crypto'),
+    md5 = crypto.createHash('md5'),
     parse = require('./parse');
 
 /**
@@ -187,7 +189,7 @@ MultiPartUpload.prototype._handleStream = function(stream, callback) {
     // Create a new part
     function newPart() {
         var partId = parts.length + 1,
-            partFileName = path.resolve(path.join(mpu.tmpDir || '', 'mpu-' + mpu.objectName + '-' + random_seed() + '-' + (mpu.uploadId || Date.now()) + '-' + partId)),
+            partFileName = path.resolve(path.join(mpu.tmpDir || '', 'mpu-' + md5.update(mpu.objectName).digest('hex') + '-' + random_seed() + '-' + (mpu.uploadId || Date.now()) + '-' + partId)),
             partFile = !mpu.noDisk && fs.createWriteStream(partFileName),
             part = {
                 id: partId,


### PR DESCRIPTION
If your object name includes a file path, it will cause the partFileName to reference a non-existent directory. Hashing keeps the disk file parts in a flat level and permits uploading to specific s3 directories.
