### PR TITLE
Fix for headers on putStream

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -293,8 +293,9 @@ MultiPartUpload.prototype._uploadPart = function(part, callback) {
     }
 
     var url = this.objectName + '?partNumber=' + part.id + '&uploadId=' + this.uploadId,
-        headers = { 'Content-Length': part.length },
-        req = this.client.request('PUT', url, headers),
+        headers = this.headers;
+        headers['Content-Length'] = part.length;
+        var req = this.client.request('PUT', url, headers),
         partStream = !this.noDisk && fs.createReadStream(part.fileName, {start: part.offset, end: part.offset + part.length - 1}),
         mpu = this,
         written = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knox-mpu",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Provide multi part upload functionality to Amazon S3 using the knox library",
   "keywords": [
     "aws",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knox-mpu",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Provide multi part upload functionality to Amazon S3 using the knox library",
   "keywords": [
     "aws",


### PR DESCRIPTION
The headers were being **hard coded** and not using the options passed in. This is a must to solve for permissions for file type headers.

@nathanoehlman please merge asap. large hold up for using this library. 