### PR TITLE
BE-391 - Exception When Getting Temp Dir

### DIFF
--- a/lib/multipartupload.js
+++ b/lib/multipartupload.js
@@ -60,8 +60,8 @@ function MultiPartUpload(opts, callback) {
     this.size = 0;
     this.parts = [];
 
-    // initialise the tmp directory based on opts (fallback to os.tmpDir())
-    this.tmpDir = !this.noDisk && (opts.tmpDir || os.tmpDir());
+    // initialise the tmp directory based on opts (fallback to os.tmpdir())
+    this.tmpDir = !this.noDisk && (opts.tmpDir || os.tmpdir());
 
     var mpu = this;
 


### PR DESCRIPTION
tmpDir() was deprecated in 2018.